### PR TITLE
Update ART_IMAGE URL in config/index.js

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -8,7 +8,7 @@ export const LINK_SOURCES = {
   PROFILE_IMAGE:
     "https://portfoliodata.djdiptayan.in/media/profile_pic.jpeg",
   ART_IMAGE:
-    "https://portfoliodata.djdiptayan.in/cover.png",
+    "https://portfoliodata.djdiptayan.in/media/cover.png",
   RESUME:
     "https://portfoliodata.djdiptayan.in/media/resume.pdf",
   EXPERIENCE_API:


### PR DESCRIPTION
This pull request updates the URL for the ART_IMAGE in the config/index.js file. The previous URL was pointing to "https://portfoliodata.djdiptayan.in/cover.png", and it has been updated to "https://portfoliodata.djdiptayan.in/media/cover.png". This change ensures that the correct image is displayed for the ART_IMAGE.