### PR TITLE
Update links to "/contact" in AboutIntro and AboutStory components

### DIFF
--- a/components/about/Intro.jsx
+++ b/components/about/Intro.jsx
@@ -22,7 +22,7 @@ const AboutIntro = () => {
       </p>
       <div className="mx-auto mt-8 flex w-full flex-col items-center justify-center gap-4 md:max-w-sm md:flex-row">
         <Link
-          href="/"
+          href="/contact"
           className="flex w-full items-center justify-center gap-2 rounded-xl bg-themes-txt_primary px-8 py-4 font-semibold text-themes-bg_primary transition-all duration-300 hover:-translate-y-1 hover:bg-portfolio-accent"
         >
           <FaEnvelope /> Get in touch

--- a/components/about/Story.jsx
+++ b/components/about/Story.jsx
@@ -40,7 +40,7 @@ const AboutStory = () => {
                 </p>
                 <Link
                     //REPLACE WITH YOUR CONTACT PAGE LINK
-                    href="/#"
+                    href="/contact"
                     className="mt-4 flex w-full items-center justify-center gap-2 rounded-xl bg-themes-txt_primary px-8 py-4 font-semibold text-themes-bg_primary transition-all duration-300 hover:-translate-y-1 hover:bg-portfolio-accent md:w-fit"
                 >
                     <FaEnvelope /> Get in touch


### PR DESCRIPTION
This pull request updates the links in the AboutIntro and AboutStory components to point to "/contact" instead of the previous placeholder links. This ensures that users are directed to the correct contact page when clicking on the "Get in touch" button.